### PR TITLE
Prevent early release of memory by GC

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -21,6 +21,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -171,6 +172,7 @@ func (backend *Backend) Decode(frags [][]byte) ([]byte, error) {
 		return nil, fmt.Errorf("decode() returned %v", errToName(-rc))
 	}
 	defer C.liberasurecode_decode_cleanup(backend.libecDesc, data)
+	runtime.KeepAlive(frags) // prevent frags from being GC-ed during decode
 	return C.GoBytes(unsafe.Pointer(data), C.int(dataLength)), nil
 }
 
@@ -193,6 +195,7 @@ func (backend *Backend) Reconstruct(frags [][]byte, fragIndex int) ([]byte, erro
 		C.uint64_t(len(frags[0])), C.int(fragIndex), pData); rc != 0 {
 		return nil, fmt.Errorf("reconstruct_fragment() returned %v", errToName(-rc))
 	}
+	runtime.KeepAlive(frags) // prevent frags from being GC-ed during reconstruct
 	return data, nil
 }
 


### PR DESCRIPTION
Adds a new test on decode: run multiple goroutines in parallel to force
the GC to wake up and possibly reallocate in-use memory

The apparent issue with GC is that allocated blocks are no longer in use
from go point of view (but actually are referenced by C layer).

Adding a runtime.KeepAlive(block) prevents the GC to release/reallocate
the memory.

Impacts Reconstruct & Decode